### PR TITLE
station details popups

### DIFF
--- a/assets/css/map.css
+++ b/assets/css/map.css
@@ -1,3 +1,18 @@
 #map-container:empty{
   display:none;
 }
+.H_ib_content{
+  margin:0;
+  max-width:90%;
+}
+.H_ib_content > .card p{
+  margin-bottom:0;
+}
+.H_ib_content > .card{
+  width:max-content;
+  box-shadow:none;
+}
+.station-info{
+  display:grid;
+  grid-template-columns:auto 1fr;
+}

--- a/assets/javascript/search.js
+++ b/assets/javascript/search.js
@@ -85,6 +85,11 @@ const validInput = () => {
 };
 //#region station searching
 
+/**
+ * Initiates a fetch request to NREL to look for nearby stations.
+ * @param {object} parameters - The query parameters to send in the API fetch call
+ * @returns {Promise} - Resolves to the json parsed data on nearby stations from NREL
+ */
 const getNearestStations = function(parameters={}){
   const paramString = Object.entries(parameters).map(([key,val])=>`${key}=${val}`).join('&');
   return fetch(`https://developer.nrel.gov/api/alt-fuel-stations/v1/nearest.json?api_key=${nrelak}&${paramString}`)
@@ -162,7 +167,10 @@ const clearBubbles = () => {
   map.ui.getBubbles().forEach(bub => map.ui.removeBubble(bub));
 }
 
-
+/**
+ * Creates an infobubble for the clicked marker
+ * @param {EventObject} event - The event that triggered the function
+ */
 const createPopup = (event)=>{
   clearBubbles();
   console.log(event.target);
@@ -174,6 +182,9 @@ const createPopup = (event)=>{
   map.ui.addBubble(bubble);
 };
 
+/**
+ * Collects the user's input to query NREL for nearby stations. Calls `createMap()` to create the map.
+ */
 const findStations = async () => {
   const locationName = $searchInput.val() || 'USECURRENT';
   const selectedLocation = userLocations[locationName];
@@ -281,6 +292,11 @@ const searchCities = async ()=>{
 const debouncedSearch = debounce(searchCities,250);
 
 //#endregion City searching
+
+/**
+ * Invoked when the user submits the search form. Checks all inputs to make sure that a valid option has been selected, or valid entry made.
+ * @param {EventObject} event - The event that triggered the function
+ */
 const verifySelections = (event)=>{
   event.preventDefault();
   const $fuelType = $('#fuel-type');
@@ -327,6 +343,7 @@ const fuelSpecificOptions = (event) => {
   }
 };
 //#endregion Listener Functions
+
 //#region Listener declarations
 $currentButton.click(useCurrentLocation);
 $form.submit(verifySelections);

--- a/index.html
+++ b/index.html
@@ -277,7 +277,7 @@
       </div>
     </template>
     <template id="marker-content">
-      <div class="card">
+      <div class="marker card">
         {{#image}}
           <div class="card-image is-centered">
             <figure class="image">

--- a/index.html
+++ b/index.html
@@ -8,8 +8,6 @@
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons"
       rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
-    <link rel="stylesheet" href="./assets/css/style.css">
-    <link rel="stylesheet" href="./assets/css/map.css">
     <script src="https://js.api.here.com/v3/3.1/mapsjs-core.js"
   type="text/javascript" charset="utf-8"></script>
     <script src="https://js.api.here.com/v3/3.1/mapsjs-service.js"
@@ -20,6 +18,8 @@
     <link rel="stylesheet" type="text/css"
         href="https://js.api.here.com/v3/3.1/mapsjs-ui.css" />
     <script src="https://kit.fontawesome.com/619ebb2432.js" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="./assets/css/style.css">
+    <link rel="stylesheet" href="./assets/css/map.css">
   </head>
   <body>
     <!-- <nav class="navbar has-shadow is-primary">
@@ -276,6 +276,73 @@
         </div>
       </div>
     </template>
+    <template id="marker-content">
+      <div class="card">
+        {{#image}}
+          <div class="card-image is-centered">
+            <figure class="image">
+              <img src="{{image}}" alt="{{imagealt}}">
+            </figure>
+          </div>
+        {{/image}}
+        <div class="card-content">
+          {{#header}}
+            <div class="media">
+              <div class="media-content">
+                <h4 class="title is-5">{{title}}</h4>
+              </div>
+              <div class="media-right">
+                {{#headericons-material}}
+                  {{#.}}
+                    <span class="icon">
+                      <i class="material-icons">{{.}}</i>
+                    </span>
+                  {{/.}}
+                {{/headericons-material}}
+                {{#headericons-fa}}
+                  {{#.}}
+                  <span class="icon">
+                    <i class="fas {{.}}" aria-hidden="true"></i>
+                  </span>
+                  {{/.}}
+                {{/headericons-fa}}
+              </div>
+            </div>
+          {{/header}}
+          {{#content}}
+            <div class="content">
+              {{#address}}
+                <p>{{street}}</p>
+                <p>{{city}}, {{state}} {{zip}}</p>
+              {{/address}}
+              <div class="station-info">
+                {{#phone}}
+                  <h5>phone:</h5><span>{{phone}}</span>
+                {{/phone}}
+                {{#hours}}
+                  <h5>hours:</h5><span>{{hours}}</span>
+                {{/hours}}
+                {{#evNetwork}}
+                  <h5>EV Network:</h5><span>{{evNetwork}}</span>
+                {{/evNetwork}}
+                {{#level1}}
+                  <h5>level 1 ports:</h5><span>{{level1}}</span>
+                {{/level1}}
+                {{#level2}}
+                  <h5>level 2 ports:</h5><span>{{level2}}</span>
+                {{/level2}}
+                {{#DCFast}}
+                  <h5>DC fast ports:</h5><span>{{DCFast}}</span>
+                {{/DCFast}}
+                {{#other}}
+                  <h5>other ports:</h5><span>{{other}}</span>
+                {{/other}}
+              </div>
+            </div>
+          {{/content}}
+        </div>
+      </div>
+    </template>
     <!-- End Bulma Templates -->
       <!-- This is the footer -->
       <footer class="footer">
@@ -287,7 +354,12 @@
         </div>
       </footer>
     <!-- JS scripts -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/mustache.js/4.1.0/mustache.min.js"
+        integrity="sha512-HYiNpwSxYuji84SQbCU5m9kHEsRqwWypXgJMBtbRSumlx1iBB6QaxgEBZHSHEGM+fKyCX/3Kb5V5jeVXm0OglQ=="
+        crossorigin="anonymous"></script>
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+    <script type="text/worker">
+    </script>
     <!-- Initialize HERE API -->
     <script src="assets/javascript/here-ini.js">
     </script>


### PR DESCRIPTION
## Changelog
### Dependencies
- Added Mustache.js library CDN call
### Features
- Added marker info bubble popups to the map. They currently include the following information (if it is available for the station)
  - station name
  - address
  - phone
  - hours of operation
  - ev charge network name
  - number of level 1 connectors
  - number of level 2 connectors
  - number of DC fast connectors
  - Other connectors available
### Code
- Added a `marker-content` template element to `index.html` to use as a template for creating the infobubbles. The template uses mustache syntax to allow it to render the information that is available.